### PR TITLE
Move CI to ubuntu 20.04 from deprecated 18.04 runners

### DIFF
--- a/.github/workflows/check_release_label.yml
+++ b/.github/workflows/check_release_label.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check_labels:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: smartlyio/check-versioning-action@v5
       with:

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -15,11 +15,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Install"
@@ -40,16 +40,16 @@ jobs:
         npm run package
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       httpbin:
         image: kennethreitz/httpbin
         ports:
         - 8080:80
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Build action for test"

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -15,11 +15,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Install"
@@ -40,16 +40,16 @@ jobs:
         npm run package
 
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       httpbin:
         image: kennethreitz/httpbin
         ports:
         - 8080:80
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set Node.js 12.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v2
       with:
         node-version: 12.x
     - name: "Build action for test"
@@ -67,16 +67,16 @@ jobs:
         data: '{"my-key": "my-value"}'
 
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: "Build and release action"
     needs: [build, test]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           persist-credentials: true
       - name: Set Node.js 12.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
       - name: Configure git


### PR DESCRIPTION
GitHub is deliberately causing CI failures on ubuntu-18.04; we need to switch everything