### PR TITLE
Add missing write permission for the github_token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     name: Build and release action
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
My master push CI failed due to missing write permissions due to the new read-only global policy, so we need to explicitly grant write permissions here.